### PR TITLE
Add a rudimentary Makefile for the DITA-OT toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pdf.log
+*.pdf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+#
+# Greenplum Documentation top level Makefile
+#
+# This builstep requires the dita-ot bin/ directory to be in PATH
+#
+
+OBJS=GPAdminGuide.pdf GPRefGuide.pdf WinClientTools.pdf \
+	 gpdb-webhelp.pdf GPClientToolsUnix.pdf	GPUtilityGuide.pdf \
+	 WinLoadTools.pdf
+
+pdf: $(OBJS)
+
+all: pdf
+
+%.pdf: %.ditamap
+	dita --input=$< --format=pdf --propertyfile=$(subst ditamap,ditaval,$<) --output=./ -l $<.pdf.log
+
+clean:
+	rm -rf $(OBJS) out.log


### PR DESCRIPTION
To save having to compile the documents manually, add a first stab at a Makefile. Since the DITA-OT tools produce an overwhelming amount of output on the console, redirect to a logfile per each file. Only PDF is supported as of now simply to get started. Also add a gitignore covering the buildlogs and the generated PDF.

It should be noted that all files currently doesn't build (gpdb-webhelp fails on an invalid character) but at least this makes compiling them easily reproducible.