### PR TITLE
Make spelling of writable consistent

### DIFF
--- a/admin_guide/ddl/ddl-partition.xml
+++ b/admin_guide/ddl/ddl-partition.xml
@@ -843,7 +843,7 @@ INTO (PARTITION jan09, default partition);
                 starts the <codeph>gpfdist</codeph> protocol.
               <codeblock> $ gpfdist</codeblock></p></li>
             <li>Create a writable external table.<p>This <codeph>CREATE WRITABLE EXTENAL
-                  TABLE</codeph> command creates a writeable external table with the same columns as
+                  TABLE</codeph> command creates a writable external table with the same columns as
                 the partitioned
               table.</p><codeblock>CREATE WRITABLE EXTERNAL TABLE my_sales_ext ( LIKE sales_1_prt_yr_1 )
   LOCATION ( 'gpfdist://gpdb_test/sales_2000' )
@@ -852,7 +852,7 @@ INTO (PARTITION jan09, default partition);
             <li>Create a readable external table that reads the data from that destination of the
               writable external table created in the previous step.<p>This <codeph>CREATE EXTENAL
                   TABLE</codeph> create a readable external that uses the same external data as the
-                writeable external
+                writable external
               data.</p><codeblock>CREATE EXTERNAL TABLE sales_2000_ext ( LIKE sales_1_prt_yr_1)
   LOCATION ( 'gpfdist://gpdb_test/sales_2000' )
   FORMAT 'csv' ;</codeblock></li>

--- a/admin_guide/load/topics/g-hdfs-avro-format.xml
+++ b/admin_guide/load/topics/g-hdfs-avro-format.xml
@@ -117,7 +117,7 @@ done</codeblock></p>
                 <row>
                   <entry colname="col1">Parameter</entry>
                   <entry colname="col2">Value</entry>
-                  <entry>Readable/Writeable</entry>
+                  <entry>Readable/Writable</entry>
                   <entry colname="col3">Default Value</entry>
                 </row>
               </thead>
@@ -132,7 +132,7 @@ done</codeblock></p>
                         <li>The specified schema overrides the schema in the Avro file. See "Avro
                           Schema Overrides"</li>
                         <li>If not specified, Greenplum Database uses the Avro file schema.</li>
-                      </ul></p><p>For a writeable external table<ul id="ul_kl5_2yv_vs">
+                      </ul></p><p>For a writable external table<ul id="ul_kl5_2yv_vs">
                         <li>Uses the specified schema when creating the Avro file.</li>
                         <li>If not specified, Greenplum Database creates a schema according to the
                           external table definition.</li>
@@ -568,7 +568,7 @@ done</codeblock></p>
       <topic id="topic_ljx_2yv_vs">
         <title>Limitations</title>
         <body>
-          <p>For a Greenplum Database writeable external table definition, columns cannot specify
+          <p>For a Greenplum Database writable external table definition, columns cannot specify
             the <codeph>NOT NULL</codeph> clause.</p>
           <p>Greenplum Database does not support the Avro <codeph>map</codeph> data type and returns
             an error when encountered.</p>
@@ -593,7 +593,7 @@ done</codeblock></p>
    LOCATION ('gphdfs://my_hdfs:8020/tmp/at1
       ?schema=hdfs://my_hdfs:8020/avro/array_simple.avsc')
    FORMAT 'avro';</codeblock>
-          <p><codeph>CREATE WRITEABLE EXTERNAL TABLE</codeph> command that writes to an Avro file
+          <p><codeph>CREATE WRITABLE EXTERNAL TABLE</codeph> command that writes to an Avro file
             and specifies a namespace for the Avro schema.</p>
           <codeblock>CREATE WRITABLE EXTERNAL TABLE atudt1 (id int, info myt, birth date, salary numeric )
    LOCATION ('gphdfs://my_hdfs:8020/tmp/emp01.avro

--- a/admin_guide/load/topics/g-hdfs-parquet-format.xml
+++ b/admin_guide/load/topics/g-hdfs-parquet-format.xml
@@ -425,7 +425,7 @@ done</codeblock></p>
                 <row>
                   <entry colname="col1">Option</entry>
                   <entry colname="col2">Values</entry>
-                  <entry>Readable/Writeable</entry>
+                  <entry>Readable/Writable</entry>
                   <entry colname="col3">Default Value</entry>
                 </row>
               </thead>

--- a/admin_guide/load/topics/g-s3-protocol.xml
+++ b/admin_guide/load/topics/g-s3-protocol.xml
@@ -10,10 +10,10 @@
       <p>The <codeph>s3</codeph> protocol is used in a URL that specifies the location of an Amazon
          S3 bucket and a prefix to use for reading or writing files in the bucket. You can define
          read-only external tables that use existing data files in the S3 bucket for table data, or
-         writeable external tables that store the data from INSERT operations to files in the S3
+         writable external tables that store the data from INSERT operations to files in the S3
          bucket. Greenplum Database uses the S3 URL and prefix specified in the protocol URL either
          to select one or more files for a read-only table, or to define the location and filename
-         format to use when uploading S3 files for <codeph>INSERT</codeph> operations to writeable
+         format to use when uploading S3 files for <codeph>INSERT</codeph> operations to writable
          tables.</p>
       <p>This topic contains the sections:<ul id="ul_o15_22r_kx">
             <li><xref href="#amazon-emr/s3_prereq" format="dita"/></li>
@@ -90,7 +90,7 @@
    location('s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/
       config=/home/gpadmin/aws_s3/s3.conf')
    FORMAT 'csv';</codeblock><p>For
-                     writeable S3 tables, the protocol URL defines the S3 location in which
+                     writable S3 tables, the protocol URL defines the S3 location in which
                      Greenplum database stores data files for the table, as well as a prefix to use
                      when creating files for table <codeph>INSERT</codeph> operations. For
                      example:<codeblock>CREATE WRITABLE EXTERNAL TABLE S3WRIT (LIKE S3TBL)
@@ -110,13 +110,13 @@
          <p>The <codeph>s3</codeph> protocol URL must the AWS S3 endpoint and S3 bucket name. Each
             Greenplum Database segment instance must have access to the S3 location. The optional
                <varname>S3_prefix</varname> value is used to select files for read-only S3 tables,
-            or as a filename prefix to use when uploading files for S3 writeable tables.</p>
+            or as a filename prefix to use when uploading files for S3 writable tables.</p>
          <note id="s3-prefix-note">Although the <varname>S3_prefix</varname> is an optional part of
-            the syntax, you should always include an S3 prefix for both writeable and read-only S3
+            the syntax, you should always include an S3 prefix for both writable and read-only S3
             tables to separate datasets as part of the <xref
                href="../../../ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml#topic1"/>
             syntax.</note>
-         <p>For writeable S3 tables, the <codeph>s3</codeph> protocol URL specifies the endpoint and
+         <p>For writable S3 tables, the <codeph>s3</codeph> protocol URL specifies the endpoint and
             bucket name where Greenplum Database uploads data files for the table. The S3 bucket
             permissions must be <codeph>Upload/Delete</codeph> for the S3 user ID that uploads the
             files. The S3 file prefix is used for each new file uploaded to the S3 location as a
@@ -174,7 +174,7 @@ s3://domain/test1/abcdefff</codeblock>
       </section>
       <section id="section_c2f_zvs_3x">
          <title>About S3 Data Files</title>
-         <p>For each <codeph>INSERT</codeph> operation to a writeable S3 table, each Greenplum
+         <p>For each <codeph>INSERT</codeph> operation to a writable S3 table, each Greenplum
             Database segment uploads a single file to the configured the S3 bucket using the
             filename format <codeph>
                &lt;prefix>&lt;segment_id>&lt;random>.&lt;extension>[.gz]</codeph> where:<ul
@@ -185,13 +185,13 @@ s3://domain/test1/abcdefff</codeblock>
                   filename is unique.</li>
                <li><codeph>&lt;extension></codeph> describes the file type (<codeph>.txt</codeph> or
                      <filepath>.csv</filepath>, depending on the value you provide in the
-                     <codeph>FORMAT</codeph> clause of <codeph>CREATE WRITEABLE EXTERNAL
+                     <codeph>FORMAT</codeph> clause of <codeph>CREATE WRITABLE EXTERNAL
                      TABLE</codeph>). Files created by the <codeph>gpcheckcloud</codeph> utility
                   always uses the extension <filepath>.data</filepath>.</li>
                <li><filepath>.gz</filepath> is appended to the filename if compression is enabled
-                  for S3 writeable tables (the default).</li>
+                  for S3 writable tables (the default).</li>
             </ul></p>
-         <p>For writeable S3 tables, you can configure the buffer size and the number of threads
+         <p>For writable S3 tables, you can configure the buffer size and the number of threads
             that segments use for uploading files. See <xref href="#amazon-emr/s3_config_file"
                format="dita"/>.</p>
          <p>For read-only S3 tables, all of the files specified by the S3 file location
@@ -202,7 +202,7 @@ s3://domain/test1/abcdefff</codeblock>
             be in gzip compressed format. The <codeph>s3</codeph> protocol recognizes the gzip
             format and uncompress the files. Only the gzip compression format is supported. </p>
          <p>The S3 file permissions must be <codeph>Open/Download</codeph> and <codeph>View</codeph>
-            for the S3 user ID that is accessing the files. Writeable S3 tables require the S3 user
+            for the S3 user ID that is accessing the files. Writable S3 tables require the S3 user
             ID to have <codeph>Upload/Delete</codeph> permissions.</p>
          <p>For read-only S3 tables, each segment can download one file at a time from S3 location
             using several threads. To take advantage of the parallel processing performed by the
@@ -248,9 +248,9 @@ s3://domain/test1/abcdefff</codeblock>
             configuration by creating a single location on each segment host. Then you can specify
             the absolute path to the location with the <codeph>config</codeph> parameter in the
                <codeph>s3</codeph> protocol <codeph>LOCATION</codeph> clause. However, note that
-            both read-only and writeable S3 external tables use the same parameter values for their
+            both read-only and writable S3 external tables use the same parameter values for their
             connections. If you want to configure protocol parameters differently for read-only and
-            writeable S3 tables, then you must use two different <codeph>s3</codeph> protocol
+            writable S3 tables, then you must use two different <codeph>s3</codeph> protocol
             configuration files and specify the correct file in the <codeph>CREATE EXTERNAL
                TABLE</codeph> statement when you create each table.</p>
          <p>This example specifies a single file location in the <codeph>s3</codeph> directory of
@@ -280,7 +280,7 @@ chunksize = 67108864</codeblock></p>
                </plentry>
                <plentry>
                   <pt>autocompress</pt>
-                  <pd>For writeable S3 external tables, this parameter specifies whether to compress
+                  <pd>For writable S3 external tables, this parameter specifies whether to compress
                      files (using gzip) before uploading to S3. Files are compressed by default if
                      you do not specify this parameter.</pd>
                </plentry>
@@ -288,7 +288,7 @@ chunksize = 67108864</codeblock></p>
                   <pt>chunksize</pt>
                   <pd>The buffer size that each segment thread uses for reading from or writing to
                      the S3 server. The default is 64 MB. The minimum is 8MB and the maximum is
-                     128MB. <p>When inserting data to a writeable S3 table, each Greenplum Database
+                     128MB. <p>When inserting data to a writable S3 table, each Greenplum Database
                         segment writes the data into its buffer (using multiple threads up to the
                            <codeph>threadnum</codeph> value) until it is full, after which it writes
                         the buffer to a file in the S3 bucket. This process is then repeated as
@@ -297,7 +297,7 @@ chunksize = 67108864</codeblock></p>
                         multipart uploads, the minimum <codeph>chunksize</codeph> value of 8MB
                         supports a maximum insert size of 80GB per Greenplum database segment. The
                         maximum <codeph>chunksize</codeph> value of 128MB supports a maximum insert
-                        size 1.28TB per segment. For writeable S3 tables, you must ensure that the
+                        size 1.28TB per segment. For writable S3 tables, you must ensure that the
                            <codeph>chunksize</codeph> setting can support the anticipated table size
                         of your table. See <xref
                            href="http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html"
@@ -357,12 +357,12 @@ chunksize = 67108864</codeblock></p>
                         >http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region</xref>.</p></li>
                <li>S3 encryption is not supported. The S3 file property <uicontrol>Server Side
                      Encryption</uicontrol> must be <codeph>None</codeph>.</li>
-               <li>For writeable S3 external tables, only the <codeph>INSERT</codeph> operation is
+               <li>For writable S3 external tables, only the <codeph>INSERT</codeph> operation is
                   supported. <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, and
                      <codeph>TRUNCATE</codeph> operations are not supported.</li>
                <li>Because Amazon S3 allows a maximum of 10,000 parts for multipart uploads, the
                   maximum <codeph>chunksize</codeph> value of 128MB supports a maximum insert size
-                  of 1.28TB per Greenplum database segment for writeable s3 tables. You must ensure
+                  of 1.28TB per Greenplum database segment for writable s3 tables. You must ensure
                   that the <codeph>chunksize</codeph> setting can support the anticipated table size
                   of your table. See <xref
                      href="http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html"

--- a/admin_guide/managing/gptransfer.xml
+++ b/admin_guide/managing/gptransfer.xml
@@ -48,23 +48,23 @@
     </section>
     <section>
       <title>What gptransfer Does</title>
-      <p><codeph>gptransfer</codeph> uses writeable and readable external tables, the Greenplum
+      <p><codeph>gptransfer</codeph> uses writable and readable external tables, the Greenplum
           <codeph>gpfdist</codeph> parallel data-loading utility, and named pipes to transfer data
         from the source database to the destination database. Segments on the source cluster select
-        from the source database table and insert into a writeable external table. Segments in the
+        from the source database table and insert into a writable external table. Segments in the
         destination cluster select from a readable external table and insert into the destination
-        database table. The writeable and readable external tables are backed by named pipes on the
+        database table. The writable and readable external tables are backed by named pipes on the
         source cluster's segment hosts, and each named pipe has a <codeph>gpfdist</codeph> process
         serving the pipe's output to the readable external table on the destination segments. </p>
       <p><codeph>gptransfer</codeph> orchestrates the process by processing the database objects to
         be transferred in batches. For each table to be transferred, it performs the following
           tasks:<ul id="ul_wsd_4tg_dp">
-          <li>creates a writeable external table in the source database</li>
+          <li>creates a writable external table in the source database</li>
           <li>creates a readable external table in the destination database</li>
           <li>creates named pipes and <codeph>gpfdist</codeph> processes on segment hosts in the
             source cluster</li>
           <li>executes a <codeph>SELECT INTO</codeph> statement in the source database to insert the
-            source data into the writeable external table</li>
+            source data into the writable external table</li>
           <li>executes a <codeph>SELECT INTO</codeph> statement in the destination database to
             insert the data from the readable external table into the destination table</li>
           <li>optionally validates the data by comparing row counts or MD5 hashes of the rows in the
@@ -95,7 +95,7 @@
           <codeph>gpfdist</codeph> per segment host.</p>
       <p>When the destination cluster is smaller than the source cluster, there is one named pipe
         per segment host and all segments on the host send their data through it. The segments on
-        the source host write their data to a writeable web external table connected to a
+        the source host write their data to a writable web external table connected to a
           <codeph>gpfdist</codeph> process on the input end of the named pipe. This consolidates the
         table data into a single named pipe. A <codeph>gpfdist</codeph> process on the output of the
         named pipe serves the consolidated data to the destination cluster. The following figure

--- a/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
+++ b/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
@@ -181,7 +181,7 @@ CREATE WRITABLE EXTERNAL WEB TABLE <varname>table_name</varname>
         </plentry>
         <plentry>
           <pt>WEB</pt>
-          <pd>Creates a readable or writeable web external table definition in Greenplum Database.
+          <pd>Creates a readable or writable web external table definition in Greenplum Database.
             There are two forms of readable web external tables – those that access files via the
               <codeph>http://</codeph> protocol or those that access data by executing OS commands.
             Writable web external tables output data to an executable program that can accept an
@@ -629,7 +629,7 @@ customer_id=123;</codeblock>
         file. After the file name, you can specify parameters with the HTTP query string syntax that
         starts with ? and uses &amp; between field value pairs.</p><p>For this example
           <varname>location</varname> parameter, this URL sets compression parameters for an Avro
-        format writeable external table.
+        format writable external table.
         <codeblock>'gphdfs://myhdfs:8081/avro/singleAvro/array2.avro?compress=true&amp;compression_type=block&amp;codec=snappy' FORMAT 'AVRO'</codeblock></p><p>See
         "Loading and Unloading Data" in the <i>Greenplum Database Administrator Guide</i> for
         information about reading and writing the Avro and Parquet format files with external
@@ -649,7 +649,7 @@ customer_id=123;</codeblock>
             <row>
               <entry colname="col1">Parameter</entry>
               <entry colname="col2">Value</entry>
-              <entry>Readable/Writeable</entry>
+              <entry>Readable/Writable</entry>
               <entry colname="col3">Default Value</entry>
             </row>
           </thead>
@@ -664,7 +664,7 @@ customer_id=123;</codeblock>
                     <li>The specified schema overrides the schema in the Avro file. See "Avro Schema
                       Overrides"</li>
                     <li>If not specified, Greenplum Database uses the Avro file schema.</li>
-                  </ul></p><p>For a writeable external table<ul id="ul_kl5_2yv_vs">
+                  </ul></p><p>For a writable external table<ul id="ul_kl5_2yv_vs">
                     <li>Uses the specified schema when creating the Avro file.</li>
                     <li>If not specified, Greenplum Database creates a schema according to the
                       external table definition.</li>
@@ -747,7 +747,7 @@ customer_id=123;</codeblock>
             <row>
               <entry colname="col1">Option</entry>
               <entry colname="col2">Values</entry>
-              <entry>Readable/Writeable</entry>
+              <entry>Readable/Writable</entry>
               <entry colname="col3">Default Value</entry>
             </row>
           </thead>

--- a/utility_guide/admin_utilities/gpcrondump.xml
+++ b/utility_guide/admin_utilities/gpcrondump.xml
@@ -527,7 +527,7 @@ gp_dump_20130514093000_regular_files</codeblock>
             files listed in the <codeph>_regular_files</codeph> file must also be backed up after
             the completion of the backup job.</pd>
           <pd>To use named pipes for a backup, you need to create the named pipes on all the
-            Greenplum Database and make them writeable before running <codeph>gpcrondump</codeph>. </pd>
+            Greenplum Database and make them writable before running <codeph>gpcrondump</codeph>. </pd>
           <pd>If <codeph>--ddboost</codeph> is specified, <codeph>-K <varname>timestamp</varname>
               [--list-backup-files]</codeph> is not supported.</pd>
         </plentry>

--- a/utility_guide/admin_utilities/gptransfer.xml
+++ b/utility_guide/admin_utilities/gptransfer.xml
@@ -74,9 +74,9 @@
       <ul>
         <li id="pk138471">The Greenplum Database utility <codeph>gpfdist</codeph> on the source
           database system. The <codeph>gpfdists</codeph> protocol is not supported.</li>
-        <li id="pk138472">Writeable external tables on the source database system and readable
+        <li id="pk138472">Writable external tables on the source database system and readable
           external tables on the destination database system.</li>
-        <li id="pk138473">Named pipes that transfer the data between a writeable external table and
+        <li id="pk138473">Named pipes that transfer the data between a writable external table and
           a readable external table.</li>
       </ul>
       <p>When copying data into the destination system, it is redistributed on the Greenplum


### PR DESCRIPTION
There were occurrences of both writable and writeable in the docs with the former being the most common as well as the spelling in the GPDB SQL syntax. Replace all occurrences of 'writeable' with 'writable' to be consistent.

This might be something which has been brought up before but unless so it seems like a good idea.